### PR TITLE
Switched broken pypip.in badges to shields.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # metastruct
 
-[![Latest Version](https://pypip.in/version/metastruct/badge.svg?style=flat)](https://pypi.python.org/pypi/metastruct/)
+[![Latest Version](https://img.shields.io/pypi/v/metastruct.svg?style=flat)](https://pypi.python.org/pypi/metastruct/)
 [![Travis](https://secure.travis-ci.org/sholsapp/metastruct.png?branch=master)](https://travis-ci.org/sholsapp/metastruct)
 
 This library, simply, translates Python dictionary objects into first-class


### PR DESCRIPTION
Hello, this is an auto-generated Pull Request. ([Feedback?](mailto:repobot@movermeyer.com?subject=pypip.in%20Badge%20Bot%20Feedback%3A%20metastruct))

Some time ago, [pypip.in](https://web.archive.org/web/20150318013508/https://pypip.in/) shut down. This broke the badges for a bunch of repositories, including `metastruct`. Thankfully, an equivalent service is run by [shields.io](https://shields.io). This pull request changes the badge to use shields.io instead.